### PR TITLE
Remove incorrect mention of React using plain JS from FAQ

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -107,7 +107,7 @@ Because
 
 
 ## Why not TypeScript? [ts]
-Picking a language is always a tradeoff, because there are good and bad parts in all languages. But just like React, Svelte, or SvelteKit, Nue is written with plain JavaScript. That's because:
+Picking a language is always a tradeoff, because there are good and bad parts in all languages. But just like Svelte or SvelteKit, Nue is written with plain JavaScript. That's because:
 
 1. ES6 is awesome: think [modules][modules], [destructuring][destroy], and the [proxy][proxy]
 


### PR DESCRIPTION
resolves #11

As mentioned there, React isn't using plain JS, but rather Flow. Leaving only Svelte and SvelteKit as example.

There are some other frameworks that could be added here (Preact, HTMX - though they use TS for their tests, or maybe since projects like Tailwind were mentioned, Bootstrap) but for this PR I just removed React from the list (and removed the comma since the list now only contains two entries)