### PR TITLE
docs: remove git folder after clone

### DIFF
--- a/docs/nuejs/getting-started.md
+++ b/docs/nuejs/getting-started.md
@@ -17,10 +17,13 @@ title: Nue JS • Getting started
 
 ``` sh
 # clone the repository
-git clone https://github.com/nuejs/create-nue.git
+git clone https://github.com/nuejs/create-nue.git --depth 1
 
 # cd to your newly created app
 cd create-nue
+
+# remove git directory
+rm -rf .git
 
 # install dependencies
 npm install


### PR DESCRIPTION
Changes:
- use `--depth 1` to not download the complete git history
- remove the git directory, so users can create their own git repo (windows cmd?)

Using a tool (like [giget or similar projects](https://github.com/unjs/giget?tab=readme-ov-file#related-projects)?) that does this automatically might be a better option.
I haven't really looked into it further, so this is just my thoughts.