### PR TITLE
docs: fix typos

### DIFF
--- a/blog/introducing-nuemark/index.md
+++ b/blog/introducing-nuemark/index.md
@@ -82,7 +82,7 @@ export function MyAlert(props: { color: string, message: string }) {
 And here's the same with [Nue template syntax](/docs/reference/template-syntax)
 
 ```
-<p @name="my-alert" style="{ color || 'red }">{ message }</p>
+<p @name="my-alert" style="color:{ color || 'red' };">{ message }</p>
 ```
 
 Look for [Nuemark API docs](/docs/reference/nuemark-api.html) for the details.

--- a/docs/concepts/nuemark.md
+++ b/docs/concepts/nuemark.md
@@ -229,7 +229,7 @@ Nuemark extends standard Markdown syntax as follows:
 Nuemark outputs headers (h1, h2, h3) with a nested anchor tag. For example `## Hello` is rendered as:
 
 ```
-<h2 id="hello"><a href="#hello"></a> Hello</h2>
+<h2 id="hello"><a href="#hello" title="Permalink for 'Hello'"></a> Hello</h2>
 ```
 
 This allows better styling and achoring of headers. Similar to what you can see on this page for example. You can customize the id with `{# custom_id }` suffix. For example:

--- a/docs/reference/configuration-options.md
+++ b/docs/reference/configuration-options.md
@@ -21,7 +21,7 @@ The base directory is where all the styles and components are loaded on the fron
 By default, Nue looks for a file named "main.js" and includes it automatically on your page requests. You can change this with this setting. For example, a value such as `['index.js']` would auto-include "index.js". See details of [JS/Typescript modules](../concepts/js-modules.html)
 
 ### bundle
-Specifies files that should be bundled so that the imported dependencies are *inlined into the file itself. For example: ´bundle: [index.js]`. See [to bundle or not to bundle](../concepts/js-modules.html#unbundled).
+Specifies files that should be bundled so that the imported dependencies are *inlined into the file itself. For example: `bundle: [index.js]`. See [to bundle or not to bundle](../concepts/js-modules.html#unbundled).
 
 
 ### class
@@ -34,7 +34,7 @@ The output directory. The default is `.dist/dev` for the development version and
 This is a directory name for a [content collection](../concepts/content-collections.html). Setting this to "posts" makes all the Markdown pages and their metadata available as a looped array for your template files. Good for making blog/docs indexes.
 
 ### collection_name
-The name of the looped variable on the content collection. By default, this is the name of the directory ie. the value of the `content_collection` option.
+The name of the looped variable on the content collection. By default, this is the name of the directory i.e. the value of the `content_collection` option.
 
 ### globals
 A site-wide setting in your `site.yaml` file to define directories that are global to all your applications. The scripts, styles, and components under global directories are automatically included on all your pages. See [files and directories](files-and-directories).

--- a/docs/reference/seo-and-metadata.md
+++ b/docs/reference/seo-and-metadata.md
@@ -98,8 +98,7 @@ Here are all the supported properties that impact the contents of your HEAD:
   The value of the `<title>` tag — the most important meta tag for SEO. By default this is the value of the Markdown `# Level one title` if not explicitly defined.
 
   ### title_template
-  Allows formatting the value of the `<title>` tag in the way you like. A value such as `'%s | Acme Inc.'` prints "My page | Acme Inc" where the `%s` token with the page title.
-
+  Allows formatting the value of the `<title>` tag in the way you like. A value such as `'%s | Acme Inc.'` prints "My page | Acme Inc." where the `%s` token is the page title.
 
   ### viewport
   The [viewport](//developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) value. The default is: "width=device-width,initial-scale=1"


### PR DESCRIPTION
Also, the following HTML comment contains a `.js` extension, even though, the file (code block) contains HTML:
https://github.com/nuejs/www/blob/015e80e2c631c91cb4848c99465a5769497a5a24/docs/concepts/js-modules.md?plain=1#L43-L44

Not sure about the name `app`, too, as I haven't used SPA yet.