### PR TITLE
docs: fix typo

### DIFF
--- a/docs/reference/reactive-components.md
+++ b/docs/reference/reactive-components.md
@@ -358,7 +358,7 @@ Here's an example library that defines both a shopping cart and a button compone
 ```
 <!-- shared code -->
 <script>
-!  import { shopping_cart, addToCart } from './cart.js'
+|  import { shopping_cart, addToCart } from './cart.js'
 </script>
 
 <!-- shopping bag component -->


### PR DESCRIPTION
I think, the `!` should be a `|` like here:

https://github.com/nuejs/www/blob/4cefb245e9a960a1b4bd602646548f166e3bf791/docs/reference/reactive-components.md?plain=1#L252-L254

Which looks like it will add a highlight to a line:
![image](https://github.com/nuejs/www/assets/44443899/f122f577-214c-4e64-9e9b-1b3e9a117ee0)

Correct me if I'm wrong. Thanks.