### PR TITLE
📱 fix: pre codeblocks responsiveness for @small screens 

### DIFF
--- a/docs/style/content.style
+++ b/docs/style/content.style
@@ -80,7 +80,7 @@ h2 + ul
 
 @small-
   pre
-    font 1.1em
+    overflow-x scroll
 
 .cols
   gap 2em


### PR DESCRIPTION
# code fix
font-size is overwritten by g**low**, so I have added overf**low**

Fixes #50


# before : #50
# after 

![Screenshot_2024-02-06-01-27-57-08_4d38fce200f96aeac5e860e739312e76.jpg](https://github.com/nuejs/www/assets/69188140/82af3540-16a0-4a38-9957-664f9b4ba74a)

![Screenshot_2024-02-06-01-27-47-22_4d38fce200f96aeac5e860e739312e76.jpg](https://github.com/nuejs/www/assets/69188140/008a3a3e-92e1-4ffc-b410-ae2530ea2acb)

![Screenshot_2024-02-06-01-27-42-41_4d38fce200f96aeac5e860e739312e76.jpg](https://github.com/nuejs/www/assets/69188140/c627208d-5f52-40b6-b8aa-2b8626063236)

![Screenshot_2024-02-06-01-27-31-44_4d38fce200f96aeac5e860e739312e76.jpg](https://github.com/nuejs/www/assets/69188140/e2e6bcc5-16f7-4d34-a401-80aa3ee8a6fa)

