### PR TITLE
fix: typo in blog articles

### DIFF
--- a/blog/nuekit-010/index.md
+++ b/blog/nuekit-010/index.md
@@ -109,7 +109,7 @@ Check out our [Getting Started guide](/docs/) to learn the details
 
 
 ## What is Nue?
-*Nue* is the umbrella term for all Nue-related projects. It's a rather ambitious project to build a simpler and more powerful alternative to services like *Vercel*, *Gatsby*, and *Nelify*. Today, with the announcement of Nuekit we are significantly closer to the goal:
+*Nue* is the umbrella term for all Nue-related projects. It's a rather ambitious project to build a simpler and more powerful alternative to services like *Vercel*, *Gatsby*, and *Netlify*. Today, with the announcement of Nuekit we are significantly closer to the goal:
 
 
 [media]

--- a/blog/tailwind-vs-semantic-css/index.md
+++ b/blog/tailwind-vs-semantic-css/index.md
@@ -217,7 +217,7 @@ The fact is that Tailwind's popularity will eventually fade. CSS-in-JS is trendi
 
 
 ### What is Nue?
-*Nue* is the umbrella term for all Nue-related projects. It's a rather ambitious project to build a simpler and more powerful alternative to services like *Vercel*, *Gatsby*, and *Nelify*.
+*Nue* is the umbrella term for all Nue-related projects. It's a rather ambitious project to build a simpler and more powerful alternative to services like *Vercel*, *Gatsby*, and *Netlify*.
 
 
 [media]


### PR DESCRIPTION
This PR:
- fixes typo in the word `Netlify` for two blog articles